### PR TITLE
improvement(filteraudiorender): update nb_samples in renderFrame

### DIFF
--- a/framework/render/audio/filterAudioRender.cpp
+++ b/framework/render/audio/filterAudioRender.cpp
@@ -41,6 +41,10 @@ namespace Cicada {
         }
 
         mOutputInfo = mInputInfo = *info;
+        /*
+         * the nb_samples may not correct, update the value in renderFrame
+         */
+        mOutputInfo.nb_samples = 0;
         int ret = init_device();
 
         if (ret < 0) {


### PR DESCRIPTION
the nb_samples would not correct before decode, update it with frame info

Signed-off-by: pingkai <pingkai010@gmail.com>