### PR TITLE
Revert "refactor(player): use getAudioPlayTimeStamp to check delay"

### DIFF
--- a/mediaPlayer/SuperMediaPlayer.cpp
+++ b/mediaPlayer/SuperMediaPlayer.cpp
@@ -1429,13 +1429,7 @@ namespace Cicada {
             int64_t lastAudio = mBufferController.GetPacketLastPTS(BUFFER_TYPE_AUDIO);
 
             if ((lastAudio != INT64_MIN) && (mPlayedAudioPts != INT64_MIN)) {
-                int64_t playTime = getAudioPlayTimeStamp();
-
-                if (INT64_MIN == playTime) {
-                    playTime = mPlayedAudioPts;
-                }
-
-                int64_t delayTime = lastAudio - playTime;
+                int64_t delayTime = lastAudio - mPlayedAudioPts;
                 static int64_t lastT = af_gettime_ms();
 
                 if (af_gettime_ms() - lastT > 1000) {


### PR DESCRIPTION
This reverts commit 56571ba61ccc8e77d3a53fff98d5bc354ec4fd81.