### PR TITLE
fix(ios): use UIApplicationStateBackground to detact bg status

### DIFF
--- a/platform/Apple/source/CicadaPlayer.mm
+++ b/platform/Apple/source/CicadaPlayer.mm
@@ -151,7 +151,7 @@ static int logOutput = 1;
                                                      name:UIApplicationWillTerminateNotification
                                                    object:nil];
 
-        if (UIApplicationStateActive != [[UIApplication sharedApplication] applicationState]) {
+        if (UIApplicationStateBackground == [[UIApplication sharedApplication] applicationState]) {
             self.player->EnterBackGround(true);
         }
 #endif // TARGET_OS_IPHONE


### PR DESCRIPTION
workaround some ipad in error UIApplicationStateInactive status

Signed-off-by: pingkai <pingkai010@gmail.com>