### PR TITLE
improvement(sdlVideoRender): fix bug that captureScreen() capture pre…

### DIFF
--- a/framework/render/video/SdlAFVideoRender.cpp
+++ b/framework/render/video/SdlAFVideoRender.cpp
@@ -381,7 +381,7 @@ void SdlAFVideoRender::captureScreen(std::function<void(uint8_t *data, int width
         AF_LOGE("Texture could not be created! SDL_Error: %s\n", SDL_GetError());
         return;
     }
-
+    refreshScreen();
     Uint32 surfaceFormat = surface->format->format;
     {
         std::unique_lock<std::mutex> lock(mRenderMutex);


### PR DESCRIPTION
…vious frame instead of the current frame