### PR TITLE
perf(audiorender): improve preformace in iOS audio render

### DIFF
--- a/framework/filter/IAudioFilter.h
+++ b/framework/filter/IAudioFilter.h
@@ -12,6 +12,8 @@
 using namespace std;
 namespace Cicada{
     class IAudioFilter {
+#define A_FILTER_FLAG_TEMPO (1 << 1)
+#define A_FILTER_FLAG_VOLUME (1 << 2)
     public:
         typedef IAFFrame::audioInfo format;
 
@@ -22,8 +24,7 @@ namespace Cicada{
 //        virtual bool beSupported(const char* capacity) = 0;
         virtual bool setOption(const string &key, const string &value, const string &capacity) = 0;
 
-        attribute_warn_unused_result
-        virtual int init() = 0;
+        attribute_warn_unused_result virtual int init(uint64_t flags) = 0;
 
         virtual int push(std::unique_ptr<IAFFrame> &frame, uint64_t timeOut) = 0;
 

--- a/framework/filter/ffmpegAudioFilter.cpp
+++ b/framework/filter/ffmpegAudioFilter.cpp
@@ -168,9 +168,10 @@ namespace Cicada {
         return err;
     }
 
-    int ffmpegAudioFilter::init()
+    int ffmpegAudioFilter::init(uint64_t flags)
     {
         int err;
+        mFlags = flags;
         m_pFilterGraph = avfilter_graph_alloc();
 
         if (m_pFilterGraph == nullptr) {
@@ -194,8 +195,10 @@ namespace Cicada {
         char options_str[1024];
         bool needAFormat = false;
         // for now enlarge only
-        snprintf(options_str, sizeof(options_str), "volume=%f", std::max(mVolume, 1.0));
-        err = addFilter(&current, "volume", options_str);
+        if (flags & A_FILTER_FLAG_VOLUME) {
+            snprintf(options_str, sizeof(options_str), "volume=%f", std::max(mVolume, 1.0));
+            err = addFilter(&current, "volume", options_str);
+        }
 
         if (err == 0 //volume would add a aformat filter too
                 || mSrcFormat.sample_rate != mDstFormat.sample_rate
@@ -204,8 +207,10 @@ namespace Cicada {
             needAFormat = true;
         }
 
-        snprintf(options_str, sizeof(options_str), "tempo=%f", mRate.load());
-        addFilter(&current, "atempo", options_str);
+        if (flags & A_FILTER_FLAG_TEMPO) {
+            snprintf(options_str, sizeof(options_str), "tempo=%f", mRate.load());
+            addFilter(&current, "atempo", options_str);
+        }
 
         if (needAFormat) {
             snprintf(options_str, sizeof(options_str),
@@ -290,7 +295,7 @@ namespace Cicada {
                 std::lock_guard<std::mutex> uMutex(mMutexRate);
 
                 if (m_pFilterGraph == nullptr) {
-                    ret = init();
+                    ret = init(mFlags);
 
                     if (ret < 0) {
                         AF_LOGE("init error\n");

--- a/framework/filter/ffmpegAudioFilter.h
+++ b/framework/filter/ffmpegAudioFilter.h
@@ -24,7 +24,7 @@ namespace Cicada {
 
         bool setOption(const string &key, const string &value, const string &capacity) override;
 
-        int init() override;
+        int init(uint64_t flags) override;
 
 
         int push(std::unique_ptr<IAFFrame> &frame, uint64_t timeOut) override;
@@ -59,6 +59,8 @@ namespace Cicada {
 
         std::atomic<int64_t> mLastInputPts {INT64_MIN};
         std::atomic<int64_t> mLastInPutDuration {0};
+
+        uint64_t mFlags{0};
 
         int addFilter(AVFilterContext **current, const char *name, const char *options_str);
     };

--- a/framework/render/audio/Android/AudioTrackRender.h
+++ b/framework/render/audio/Android/AudioTrackRender.h
@@ -38,6 +38,11 @@ private:
 
     uint64_t device_get_que_duration() override;
 
+    uint64_t device_get_ability() override
+    {
+        return 0;
+    }
+
 private:
     AudioTrackRender(int dummy) : mFrameQueue(1)
     {

--- a/framework/render/audio/Apple/AFAudioQueueRender.cpp
+++ b/framework/render/audio/Apple/AFAudioQueueRender.cpp
@@ -78,6 +78,14 @@ AFAudioQueueRender::~AFAudioQueueRender()
 void AFAudioQueueRender::fillAudioFormat()
 {
     int bytesPerSample = 2;
+    /*
+     * There is a performance problem when use copyPCMData to copy a planer audio,
+     * use ffmpeg filter convert it to packed audio
+     */
+    if (mOutputInfo.format >= AF_SAMPLE_FMT_U8P) {
+        mOutputInfo.format -= AF_SAMPLE_FMT_U8P;
+        needFilter = true;
+    }
 
     switch (mOutputInfo.format) {
         case AF_SAMPLE_FMT_S16:

--- a/framework/render/audio/Apple/AFAudioQueueRender.h
+++ b/framework/render/audio/Apple/AFAudioQueueRender.h
@@ -50,6 +50,11 @@ namespace Cicada {
 
         uint64_t device_get_que_duration() override;
 
+        uint64_t device_get_ability() override
+        {
+            return (uint64_t) A_FILTER_FLAG_TEMPO;
+        }
+
     private:
         explicit AFAudioQueueRender(int dummy);
 

--- a/framework/render/audio/CheaterAudioRender.h
+++ b/framework/render/audio/CheaterAudioRender.h
@@ -41,6 +41,11 @@ namespace Cicada {
 
         uint64_t device_get_que_duration() override;
 
+        uint64_t device_get_ability() override
+        {
+            return 0;
+        }
+
     private:
         af_clock mClock{};
         int64_t mPCMDuration{0};

--- a/framework/render/audio/SdlAFAudioRender.cpp
+++ b/framework/render/audio/SdlAFAudioRender.cpp
@@ -210,7 +210,7 @@ namespace Cicada {
 
         if (mFiler == nullptr) {
             mFiler = std::unique_ptr<ffmpegAudioFilter>(new ffmpegAudioFilter(mInfo, mInfo, true));
-            mFiler->init();
+            mFiler->init(A_FILTER_FLAG_VOLUME | A_FILTER_FLAG_TEMPO);
         }
 
         mFiler->setOption("volume", std::to_string(volume), "volume");
@@ -226,7 +226,7 @@ namespace Cicada {
 
         if (mFiler == nullptr) {
             mFiler = std::unique_ptr<ffmpegAudioFilter>(new ffmpegAudioFilter(mInfo, mInfo, true));
-            mFiler->init();
+            mFiler->init(A_FILTER_FLAG_VOLUME | A_FILTER_FLAG_TEMPO);
         }
 
         mFiler->setOption("rate", std::to_string(speed), "atempo");

--- a/framework/render/audio/filterAudioRender.h
+++ b/framework/render/audio/filterAudioRender.h
@@ -72,6 +72,8 @@ namespace Cicada {
             return 0;
         };
 
+        virtual uint64_t device_get_ability() = 0;
+
 
     private:
         int renderLoop();
@@ -106,6 +108,7 @@ namespace Cicada {
         std::unique_ptr<IAFFrame> mRenderFrame{nullptr};
         bool mUseActiveFilter{false};
         std::atomic_int mMaxQueSize{2};
+        uint64_t mFilterFlags{};
 
     protected:
         std::unique_ptr<afThread> mRenderThread = nullptr;


### PR DESCRIPTION
1. not use atempo filter on AudioQueue render
2. use filter to convert planer audio instead of in copyPCMData

Signed-off-by: pingkai <pingkai010@gmail.com>