### PR TITLE
fix(audiounitrender): workaround setting mVolume to 0 before start ca…

### DIFF
--- a/framework/render/audio/Apple/AFAudioUnitRender.cpp
+++ b/framework/render/audio/Apple/AFAudioUnitRender.cpp
@@ -454,6 +454,10 @@ namespace Cicada {
 
     void AFAudioUnitRender::device_setVolume(float gain)
     {
+        /*
+         * workaround setting mVolume to 0 before start can't effect immediately
+         */
+        loopChecker();
         mVolume = gain;
 #if AF_USE_MIX
         //        AudioUnitSetParameter(mAudioUnit, kAUNBandEQParam_GlobalGain, kAudioUnitScope_Global, 0, mVolume, 0);


### PR DESCRIPTION
…n't effect immediately

Signed-off-by: pingkai <pingkai010@gmail.com>