### PR TITLE
refactor(afaudioqueuerender): improve AudioQueue usage

### DIFF
--- a/framework/render/audio/Apple/AFAudioQueueRender.h
+++ b/framework/render/audio/Apple/AFAudioQueueRender.h
@@ -93,6 +93,7 @@ namespace Cicada {
         bool mPlaying{false};
         OSStatus mStartStatus{AVAudioSessionErrorCodeNone};
         unsigned int mReadOffset{0};
+        UInt32 mAudioDataByteSize{0};
     };
 }// namespace Cicada
 


### PR DESCRIPTION
1. set the buffer size to 100ms pcm data, instead of a fixed size,
the AudioQueue will callback 84ms at most when screen is turn off.

2. memset queued buffer when flush

Signed-off-by: pingkai <pingkai010@gmail.com>