### PR TITLE
chore(SuperMediaPlayer): fix not seek accurate

### DIFF
--- a/mediaPlayer/SMPMessageControllerListener.cpp
+++ b/mediaPlayer/SMPMessageControllerListener.cpp
@@ -389,6 +389,9 @@ void SMPMessageControllerListener::ProcessSetDataSourceMsg(const std::string &ur
 
 void SMPMessageControllerListener::ProcessSeekToMsg(int64_t seekPos, bool bAccurate)
 {
+    mPlayer.mSeekNeedCatch = bAccurate;
+    mPlayer.mSeekPos = seekPos;
+
     // seek before prepare, should keep mSeekPos
     if (mPlayer.mPlayStatus < PLAYER_PREPARING ||
         // if reuse player..


### PR DESCRIPTION
If player is in loading status for seek， and then seek accurate again, will not seek accurate second time.

Signed-off-by: lifujun <814084764@qq.com>