### PR TITLE
refactor(cicadaplayer.mm): return 0 when no referClock in CicadaClock…

### DIFF
--- a/platform/Apple/source/CicadaPlayer.mm
+++ b/platform/Apple/source/CicadaPlayer.mm
@@ -931,7 +931,7 @@ int64_t CicadaClockRefer(void *arg)
     if (player.referClock) {
         return player.referClock();
     }
-    return -1;
+    return 0;
 }
 
 -(void) SetClockRefer:(int64_t (^)(void))referClock


### PR DESCRIPTION
…Refer

fix #646

Signed-off-by: pingkai <pingkai010@gmail.com>